### PR TITLE
Removes the serviceName parameter from `SecondarySamplingPolicy`

### DIFF
--- a/brave/src/main/java/brave/secondary_sampling/SecondarySampling.java
+++ b/brave/src/main/java/brave/secondary_sampling/SecondarySampling.java
@@ -35,7 +35,7 @@ public final class SecondarySampling extends Propagation.Factory implements Trac
   }
 
   public static final class Builder {
-    String fieldName = "sampling", tagName = "sampled_keys", localServiceName;
+    String fieldName = "sampling", tagName = "sampled_keys";
     Propagation.Factory propagationFactory;
     SecondarySamplingPolicy policy;
 
@@ -48,16 +48,6 @@ public final class SecondarySampling extends Propagation.Factory implements Trac
     /** The ascii lowercase tag name to use. Defaults to {@code sampled_keys}. */
     public Builder tagName(String tagName) {
       this.tagName = validateAndLowercase(tagName, "tag");
-      return this;
-    }
-
-    /**
-     * Use the same value normally passed to {@link Tracing.Builder#localServiceName(String)}
-     *
-     * <p>This is used for {@link SecondarySamplingPolicy#getTriggerForService(String, String)}
-     */
-    public Builder localServiceName(String localServiceName) {
-      this.localServiceName = validateAndLowercase(localServiceName, "service");
       return this;
     }
 
@@ -82,7 +72,6 @@ public final class SecondarySampling extends Propagation.Factory implements Trac
     }
 
     public SecondarySampling build() {
-      if (localServiceName == null) throw new NullPointerException("localServiceName == null");
       if (propagationFactory == null) throw new NullPointerException("propagationFactory == null");
       if (policy == null) throw new NullPointerException("policy == null");
       return new SecondarySampling(this);
@@ -92,14 +81,13 @@ public final class SecondarySampling extends Propagation.Factory implements Trac
     }
   }
 
-  final String fieldName, tagName, localServiceName;
+  final String fieldName, tagName;
   final Propagation.Factory delegate;
   final SecondarySamplingPolicy policy;
 
   SecondarySampling(Builder builder) {
     this.fieldName = builder.fieldName;
     this.tagName = builder.tagName;
-    this.localServiceName = builder.localServiceName;
     this.delegate = builder.propagationFactory;
     this.policy = builder.policy;
   }

--- a/brave/src/main/java/brave/secondary_sampling/SecondarySamplingExtractor.java
+++ b/brave/src/main/java/brave/secondary_sampling/SecondarySamplingExtractor.java
@@ -30,14 +30,12 @@ final class SecondarySamplingExtractor<C, K> implements Extractor<C> {
   final Extractor<C> delegate;
   final Getter<C, K> getter;
   final SecondarySamplingPolicy policy;
-  final String localServiceName;
   final K samplingKey;
 
   SecondarySamplingExtractor(SecondarySampling.Propagation<K> propagation, Getter<C, K> getter) {
     this.delegate = propagation.delegate.extractor(getter);
     this.getter = getter;
     this.policy = propagation.secondarySampling.policy;
-    this.localServiceName = propagation.secondarySampling.localServiceName;
     this.samplingKey = propagation.samplingKey;
   }
 
@@ -56,7 +54,7 @@ final class SecondarySamplingExtractor<C, K> implements Extractor<C> {
       Map<String, String> parameters = nameParameters.length > 1
         ? parseParameters(nameParameters)
         : new LinkedHashMap<>();
-      if (updateparametersAndSample(samplingKey, parameters)) {
+      if (updateParametersAndSample(samplingKey, parameters)) {
         extra.sampledKeys.add(samplingKey);
         builder.sampledLocal(); // this means data will be recorded
       }
@@ -66,7 +64,7 @@ final class SecondarySamplingExtractor<C, K> implements Extractor<C> {
     return builder.build();
   }
 
-  boolean updateparametersAndSample(String samplingKey, Map<String, String> parameters) {
+  boolean updateParametersAndSample(String samplingKey, Map<String, String> parameters) {
     boolean sampled = false;
 
     // decrement ttl from upstream, if there is one
@@ -77,7 +75,7 @@ final class SecondarySamplingExtractor<C, K> implements Extractor<C> {
     }
 
     // Lookup if our node should participate in this sampling policy
-    Trigger trigger = policy.getTriggerForService(samplingKey, localServiceName);
+    Trigger trigger = policy.getTrigger(samplingKey);
     if (trigger != null) {
       // make a new sampling decision
       sampled = trigger.isSampled();

--- a/brave/src/main/java/brave/secondary_sampling/SecondarySamplingPolicy.java
+++ b/brave/src/main/java/brave/secondary_sampling/SecondarySamplingPolicy.java
@@ -23,5 +23,12 @@ public interface SecondarySamplingPolicy {
     int ttl();
   }
 
-  @Nullable Trigger getTriggerForService(String samplingKey, String serviceName);
+  /**
+   * Returns a trigger if this tracer should participate with the given {@code samplingKey}.
+   *
+   * @param samplingKey sampling key extracted from a remote request.
+   * @return a trigger if participating with this sampling key, or null to pass through data
+   * associated with it.
+   */
+  @Nullable Trigger getTrigger(String samplingKey);
 }

--- a/brave/src/test/java/brave/secondary_sampling/SecondarySamplingTest.java
+++ b/brave/src/test/java/brave/secondary_sampling/SecondarySamplingTest.java
@@ -39,9 +39,8 @@ public class SecondarySamplingTest {
   String serviceName = "auth", notServiceName = "gateway", notSpanId = "19f84f102048e047";
   TestSecondarySamplingPolicy policy = new TestSecondarySamplingPolicy();
   SecondarySampling secondarySampling = SecondarySampling.newBuilder()
-    .localServiceName(serviceName)
     .propagationFactory(B3SinglePropagation.FACTORY)
-    .policy(policy)
+    .policy(policy.forService(serviceName))
     .build();
 
   Propagation<String> propagation = secondarySampling.create(STRING);

--- a/brave/src/test/java/brave/secondary_sampling/integration/SecondarySamplingIntegratedTest.java
+++ b/brave/src/test/java/brave/secondary_sampling/integration/SecondarySamplingIntegratedTest.java
@@ -64,25 +64,22 @@ public class SecondarySamplingIntegratedTest {
 
   Function<String, TracingCustomizer> configureGatewayPlay = localServiceName -> builder -> {
     SecondarySampling.newBuilder()
-      .localServiceName(localServiceName)
       .propagationFactory(b3)
-      .policy(gatewayplayPolicy).build()
+      .policy(gatewayplayPolicy.forService(localServiceName)).build()
       .customize(builder);
     builder.spanReporter(traceForwarder);
   };
   Function<String, TracingCustomizer> configureAuthCache = localServiceName -> builder -> {
     SecondarySampling.newBuilder()
-      .localServiceName(localServiceName)
       .propagationFactory(b3)
-      .policy(authcachePolicy).build()
+      .policy(authcachePolicy.forService(localServiceName)).build()
       .customize(builder);
     builder.spanReporter(traceForwarder);
   };
   Function<String, TracingCustomizer> configureAllSampling = localServiceName -> builder -> {
     SecondarySampling.newBuilder()
-      .localServiceName(localServiceName)
       .propagationFactory(b3)
-      .policy(allPolicy).build()
+      .policy(allPolicy.forService(localServiceName)).build()
       .customize(builder);
     builder.spanReporter(traceForwarder);
   };


### PR DESCRIPTION
This was only used in tests and unnecessarily complicated wiring.

Fixes #5