### PR TITLE
Extracts SecondarySamplingState.Builder to MutableSecondarySamplingState

### DIFF
--- a/brave/src/main/java/brave/secondary_sampling/MutableSecondarySamplingState.java
+++ b/brave/src/main/java/brave/secondary_sampling/MutableSecondarySamplingState.java
@@ -21,9 +21,6 @@ import java.util.Map;
  * Mutable form of {@link SecondarySamplingState} for use in parsing and collaboration, prior to
  * marking immutable for local propagation.
  *
- * /** This type holds extracted state from a {@link SecondarySampling.Builder#fieldName(String)
- * sampling field} entry.
- *
  * <p><pre>{@code
  * // programmatic construction
  * authcacheState = MutableSecondarySamplingState.create("authcache").ttl(1);

--- a/brave/src/main/java/brave/secondary_sampling/MutableSecondarySamplingState.java
+++ b/brave/src/main/java/brave/secondary_sampling/MutableSecondarySamplingState.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.secondary_sampling;
+
+import brave.internal.Nullable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Mutable form of {@link SecondarySamplingState} for use in parsing and collaboration, prior to
+ * marking immutable for local propagation.
+ *
+ * /** This type holds extracted state from a {@link SecondarySampling.Builder#fieldName(String)
+ * sampling field} entry.
+ *
+ * <p><pre>{@code
+ * // programmatic construction
+ * authcacheState = MutableSecondarySamplingState.create("authcache").ttl(1);
+ *
+ * // parsing of the serialized form
+ * authcacheState = MutableSecondarySamplingState.parse("authcache;ttl=1");
+ * }</pre>
+ */
+// naming convention is like MutableSpan. Unlike a builder, this allows readback.
+public final class MutableSecondarySamplingState {
+  public static final MutableSecondarySamplingState create(String samplingKey) {
+    if (samplingKey == null) throw new NullPointerException("samplingKey == null");
+    if (samplingKey.isEmpty()) throw new IllegalArgumentException("samplingKey is empty");
+    return new MutableSecondarySamplingState(samplingKey);
+  }
+
+  /**
+   * Parses one entry from a comma-separated @link SecondarySampling.Builder#fieldName(String)
+   * sampling field}.
+   */
+  // Like Accept header, parameters are after semi-colon and themselves semi-colon delimited.
+  public static MutableSecondarySamplingState parse(String entry) {
+    String[] nameParameters = entry.split(";", 100);
+    MutableSecondarySamplingState result = create(nameParameters[0]);
+    for (int i = 1; i < nameParameters.length; i++) {
+      String[] nameValue = nameParameters[i].split("=", 2);
+      result.parameter(nameValue[0], nameValue[1]);
+    }
+    return result;
+  }
+
+  final String samplingKey;
+  Map<String, String> parameters = new LinkedHashMap<>();
+
+  MutableSecondarySamplingState(String samplingKey) {
+    this.samplingKey = samplingKey;
+  }
+
+  public String samplingKey() {
+    return samplingKey;
+  }
+
+  /** Retrieves the current TTL of this {@link #samplingKey()} or zero if there is none. */
+  @Nullable public int ttl() {
+    String ttl = parameter("ttl");
+    return ttl == null ? 0 : Integer.parseInt(ttl);
+  }
+
+  @Nullable public MutableSecondarySamplingState ttl(int ttl) {
+    if (ttl == 0) return removeParameter("ttl");
+    return parameter("ttl", String.valueOf(ttl));
+  }
+
+  @Nullable public String parameter(String name) {
+    if (name == null) throw new NullPointerException("name == null");
+    return parameters.get(name);
+  }
+
+  @Nullable public MutableSecondarySamplingState removeParameter(String name) {
+    if (name == null) throw new NullPointerException("name == null");
+    parameters.remove(name);
+    return this;
+  }
+
+  public MutableSecondarySamplingState parameter(String name, String value) {
+    if (name == null) throw new NullPointerException("name == null");
+    if (value == null) throw new NullPointerException("value == null");
+    parameters.put(name, value);
+    return this;
+  }
+}

--- a/brave/src/main/java/brave/secondary_sampling/SecondarySampler.java
+++ b/brave/src/main/java/brave/secondary_sampling/SecondarySampler.java
@@ -46,7 +46,7 @@ import brave.propagation.TraceContext;
 public interface SecondarySampler {
   /**
    * Returning true will sample data for the {@link TraceContext#isLocalRoot() local root} of this
-   * trace, under the the given {@link SecondarySamplingState.Builder#samplingKey()}. Returning
+   * trace, under the the given {@link MutableSecondarySamplingState#samplingKey()}. Returning
    * false ignores the sampling key.
    *
    * <p>Here's an example of evaluating participation based on a configured service name.
@@ -54,13 +54,13 @@ public interface SecondarySampler {
    * return (state) -> isSampled(state.samplingKey(), localServiceName());
    * }</pre>
    *
-   * <p><h3>The builder argument</h3>
-   * Simple use cases will only read {@link SecondarySamplingState.Builder#samplingKey()}. This
+   * <p><h3>The state argument</h3>
+   * Simple use cases will only read {@link MutableSecondarySamplingState#samplingKey()}. This
    * argument is present to allow reading other parameters or refreshing a {@link
-   * SecondarySamplingState.Builder#ttl(int)}.
+   * MutableSecondarySamplingState#ttl(int)}.
    *
    * @param state state extracted from propagated fields for this sampling key.
-   * @return true if the {@link SecondarySamplingState.Builder#samplingKey()} is sampled.
+   * @return true if the {@link MutableSecondarySamplingState#samplingKey()} is sampled.
    */
-  boolean isSampled(SecondarySamplingState.Builder state);
+  boolean isSampled(MutableSecondarySamplingState state);
 }

--- a/brave/src/main/java/brave/secondary_sampling/SecondarySamplingExtractor.java
+++ b/brave/src/main/java/brave/secondary_sampling/SecondarySamplingExtractor.java
@@ -45,10 +45,10 @@ final class SecondarySamplingExtractor<C, K> implements Extractor<C> {
     SecondarySampling.Extra extra = EXTRA_FACTORY.create();
     boolean sampledLocal = false;
     for (String entry : maybeValue.split(",", 100)) {
-      SecondarySamplingState.Builder builder = SecondarySamplingState.parseBuilder(entry);
-      boolean sampled = updateStateAndSample(builder);
+      MutableSecondarySamplingState state = MutableSecondarySamplingState.parse(entry);
+      boolean sampled = updateStateAndSample(state);
       if (sampled) sampledLocal = true;
-      extra.put(builder.build(), sampled);
+      extra.put(SecondarySamplingState.create(state), sampled);
     }
 
     if (extra.isEmpty()) return result;
@@ -59,16 +59,16 @@ final class SecondarySamplingExtractor<C, K> implements Extractor<C> {
     return builder.build();
   }
 
-  boolean updateStateAndSample(SecondarySamplingState.Builder builder) {
+  boolean updateStateAndSample(MutableSecondarySamplingState state) {
     boolean ttlSampled = false;
 
     // decrement ttl from upstream, if there is one
-    int ttl = builder.ttl();
+    int ttl = state.ttl();
     if (ttl != 0) {
-      builder.ttl(ttl - 1);
+      state.ttl(ttl - 1);
       ttlSampled = true;
     }
 
-    return ttlSampled | sampler.isSampled(builder);
+    return ttlSampled | sampler.isSampled(state);
   }
 }

--- a/brave/src/main/java/brave/secondary_sampling/SecondarySamplingState.java
+++ b/brave/src/main/java/brave/secondary_sampling/SecondarySamplingState.java
@@ -18,15 +18,14 @@ import java.util.Map;
 
 /**
  * This type holds extracted state from a {@link SecondarySampling.Builder#fieldName(String)
- * sampling field} entry.
+ * sampling field} entry. This type is immutable and intended to be used as a key in a mapping of
+ * sampling keys to local sampling decisions.
  *
+ * Ex.
  * <p><pre>{@code
- * // programmatic construction
- * mutable = MutableSecondarySamplingState.create("authcache").ttl(1);
+ * mutable = MutableSecondarySamplingState.parse("authcache;ttl=1");
  * authcacheState = SecondarySamplingState.create(mutable);
  * }</pre>
- * <p>This type is immutable and intended to be used as a key in a mapping of sampling keys to
- * local sampling decisions.
  */
 public final class SecondarySamplingState {
   public static SecondarySamplingState create(String samplingKey) {

--- a/brave/src/test/java/brave/secondary_sampling/SecondarySamplingStateTest.java
+++ b/brave/src/test/java/brave/secondary_sampling/SecondarySamplingStateTest.java
@@ -74,9 +74,9 @@ public class SecondarySamplingStateTest {
     Map<SecondarySamplingState, Boolean> keyToState = ((Extra) extracted.extra().get(0)).toMap();
     assertThat(keyToState)
       // no TTL left for the next hop
-      .containsEntry(SecondarySamplingState.newBuilder("authcache").build(), true)
+      .containsEntry(SecondarySamplingState.create("authcache"), true)
       // not sampled because there's no trigger for links
-      .containsEntry(SecondarySamplingState.newBuilder("links").build(), false);
+      .containsEntry(SecondarySamplingState.create("links"), false);
   }
 
   /** This shows an example of dynamic configuration */
@@ -110,12 +110,12 @@ public class SecondarySamplingStateTest {
 
     Map<SecondarySamplingState, Boolean> keyToState = ((Extra) extracted.extra().get(0)).toMap();
     assertThat(keyToState).containsOnly(
-      entry(SecondarySamplingState.newBuilder("links").build(), true),
+      entry(SecondarySamplingState.create("links"), true),
       // authcache triggers a ttl
-      entry(SecondarySamplingState.newBuilder("authcache")
-        .parameter("ttl", "1").build(), true),
+      entry(SecondarySamplingState.create(MutableSecondarySamplingState.create("authcache")
+        .parameter("ttl", "1")), true),
       // not sampled as we aren't in that service
-      entry(SecondarySamplingState.newBuilder("gatewayplay").build(), false)
+      entry(SecondarySamplingState.create("gatewayplay"), false)
     );
   }
 
@@ -129,20 +129,20 @@ public class SecondarySamplingStateTest {
     Map<SecondarySamplingState, Boolean> keyToState = ((Extra) extracted.extra().get(0)).toMap();
     assertThat(keyToState)
       // not sampled due to config, rather from TTL: note it is decremented
-      .containsEntry(SecondarySamplingState.newBuilder("authcache")
-        .parameter("ttl", "1").build(), true)
+      .containsEntry(SecondarySamplingState.create(MutableSecondarySamplingState.create("authcache")
+        .parameter("ttl", "1")), true)
       // not sampled as we aren't in that service
-      .containsEntry(SecondarySamplingState.newBuilder("gatewayplay").build(), false);
+      .containsEntry(SecondarySamplingState.create("gatewayplay"), false);
   }
 
   @Test public void injectWritesNewLastParentWhenSampled() {
     Extra extra = new Extra();
-    extra.put(SecondarySamplingState.newBuilder("gatewayplay")
-      .parameter("spanId", notSpanId).build(), false);
-    extra.put(SecondarySamplingState.newBuilder("links").build(), true);
-    extra.put(SecondarySamplingState.newBuilder("authcache")
+    extra.put(SecondarySamplingState.create(MutableSecondarySamplingState.create("gatewayplay")
+      .parameter("spanId", notSpanId)), false);
+    extra.put(SecondarySamplingState.create("links"), true);
+    extra.put(SecondarySamplingState.create(MutableSecondarySamplingState.create("authcache")
       .parameter("ttl", "1")
-      .parameter("spanId", notSpanId).build(), false);
+      .parameter("spanId", notSpanId)), false);
 
     TraceContext context = TraceContext.newBuilder()
       .traceId(1L).spanId(2L).sampled(false).extra(singletonList(extra)).build();

--- a/brave/src/test/java/brave/secondary_sampling/SecondarySamplingTest.java
+++ b/brave/src/test/java/brave/secondary_sampling/SecondarySamplingTest.java
@@ -75,9 +75,9 @@ public class SecondarySamplingTest {
       ((Extra) extracted.extra().get(0)).toMap();
     assertThat(stateToSampled)
       // no TTL left for the next hop
-      .containsEntry(SecondarySamplingState.newBuilder("authcache").build(), true)
+      .containsEntry(SecondarySamplingState.create("authcache"), true)
       // not sampled because there's no trigger for links
-      .containsEntry(SecondarySamplingState.newBuilder("links").build(), false);
+      .containsEntry(SecondarySamplingState.create("links"), false);
   }
 
   /** This shows an example of dynamic configuration */
@@ -112,13 +112,12 @@ public class SecondarySamplingTest {
     Map<SecondarySamplingState, Boolean> stateToSampled =
       ((Extra) extracted.extra().get(0)).toMap();
     assertThat(stateToSampled).containsOnly(
-      entry(SecondarySamplingState.newBuilder("links").build(), true),
+      entry(SecondarySamplingState.create("links"), true),
       // authcache triggers a ttl
-      entry(SecondarySamplingState.newBuilder("authcache")
-        .parameter("ttl", "1")
-        .build(), true),
+      entry(SecondarySamplingState.create(MutableSecondarySamplingState.create("authcache")
+        .parameter("ttl", "1")), true),
       // not sampled as we aren't in that service
-      entry(SecondarySamplingState.newBuilder("gatewayplay").build(), false)
+      entry(SecondarySamplingState.create("gatewayplay"), false)
     );
   }
 
@@ -133,21 +132,20 @@ public class SecondarySamplingTest {
       ((Extra) extracted.extra().get(0)).toMap();
     assertThat(stateToSampled)
       // not sampled due to config, rather from TTL: note it is decremented
-      .containsEntry(SecondarySamplingState.newBuilder("authcache")
-        .parameter("ttl", "1")
-        .build(), true)
+      .containsEntry(SecondarySamplingState.create(MutableSecondarySamplingState.create("authcache")
+        .parameter("ttl", "1")), true)
       // not sampled as we aren't in that service
-      .containsEntry(SecondarySamplingState.newBuilder("gatewayplay").build(), false);
+      .containsEntry(SecondarySamplingState.create("gatewayplay"), false);
   }
 
   @Test public void injectWritesNewLastParentWhenSampled() {
     Extra extra = new Extra();
-    extra.put(SecondarySamplingState.newBuilder("gatewayplay")
-      .parameter("spanId", notSpanId).build(), false);
-    extra.put(SecondarySamplingState.newBuilder("links").build(), true);
-    extra.put(SecondarySamplingState.newBuilder("authcache")
+    extra.put(SecondarySamplingState.create(MutableSecondarySamplingState.create("gatewayplay")
+      .parameter("spanId", notSpanId)), false);
+    extra.put(SecondarySamplingState.create("links"), true);
+    extra.put(SecondarySamplingState.create(MutableSecondarySamplingState.create("authcache")
       .parameter("ttl", "1")
-      .parameter("spanId", notSpanId).build(), false);
+      .parameter("spanId", notSpanId)), false);
 
     TraceContext context = TraceContext.newBuilder()
       .traceId(1L).spanId(2L).sampled(false).extra(singletonList(extra)).build();

--- a/brave/src/test/java/brave/secondary_sampling/TestSecondarySampler.java
+++ b/brave/src/test/java/brave/secondary_sampling/TestSecondarySampler.java
@@ -52,12 +52,12 @@ public final class TestSecondarySampler {
   }
 
   public SecondarySampler forService(String serviceName) {
-    return (builder) -> {
-      Trigger trigger = getByService(builder.samplingKey()).get(serviceName);
-      if (trigger == null) trigger = allServices.get(builder.samplingKey());
+    return (state) -> {
+      Trigger trigger = getByService(state.samplingKey()).get(serviceName);
+      if (trigger == null) trigger = allServices.get(state.samplingKey());
       if (trigger == null) return false;
       boolean sampled = trigger.isSampled();
-      if (sampled) builder.ttl(trigger.ttl()); // Set any TTL
+      if (sampled) state.ttl(trigger.ttl()); // Set any TTL
       return sampled;
     };
   }


### PR DESCRIPTION
This is just a cleanup as this is more like a mutable type than a
builder. It is awkward to see a parameter named builder in a sampler
method.