### PR TITLE
Integrates request-based sampling, which fixes a test glitch

### DIFF
--- a/brave/src/main/java/brave/secondary_sampling/SecondarySampler.java
+++ b/brave/src/main/java/brave/secondary_sampling/SecondarySampler.java
@@ -60,7 +60,7 @@ public interface SecondarySampler {
    * <pre>{@code
    * // Assume an initialized HTTP sampler exists
    * samplers.put("play", HttpRuleSampler.newBuilder()
-   *   .addRule("GET", "/play", 100) // requests per second
+   *   .addRuleWithRate("GET", "/play", 100) // requests per second
    *   .build());
    *
    * // The secondary sampler can leverage this

--- a/brave/src/main/java/brave/secondary_sampling/SecondarySampler.java
+++ b/brave/src/main/java/brave/secondary_sampling/SecondarySampler.java
@@ -13,6 +13,8 @@
  */
 package brave.secondary_sampling;
 
+import brave.http.HttpRequest;
+import brave.http.HttpRuleSampler;
 import brave.propagation.TraceContext;
 
 /**
@@ -51,16 +53,38 @@ public interface SecondarySampler {
    *
    * <p>Here's an example of evaluating participation based on a configured service name.
    * <pre>{@code
-   * return (state) -> isSampled(state.samplingKey(), localServiceName());
+   * return (request, state) -> isSampled(state.samplingKey(), localServiceName());
    * }</pre>
    *
-   * <p><h3>The state argument</h3>
+   * <p>Here's an example that uses http request properties along with the key.
+   * <pre>{@code
+   * // Assume an initialized HTTP sampler exists
+   * samplers.put("play", HttpRuleSampler.newBuilder()
+   *   .addRule("GET", "/play", 100) // requests per second
+   *   .build());
+   *
+   * // The secondary sampler can leverage this
+   * return (request, state) -> {
+   *   if (!(request instanceof HttpServerRequest)) return false; // only sample server side
+   *   HttpRequestSampler sampler = samplers.get(state.samplingKey());
+   *   if (sampler == null) return false; // key isn't configured
+   *   return Boolean.TRUE.equals(sampler.trySample((HttpServerRequest) request));
+   * };
+   * }</pre>
+   *
+   * <p><h3>The request parameter</h3></p>
+   * The request parameter may be an {@link HttpRequest}, which would allow implementation with
+   * tools like {@link HttpRuleSampler}. However, the request could also be non-HTTP. For example,
+   * it could be a gRPC or messaging request.
+   *
+   * <p><h3>The state parameter</h3>
    * Simple use cases will only read {@link MutableSecondarySamplingState#samplingKey()}. This
    * argument is present to allow reading other parameters or refreshing a {@link
    * MutableSecondarySamplingState#ttl(int)}.
    *
-   * @param state state extracted from propagated fields for this sampling key.
+   * @param request incoming request
+   * @param state a sampling key associated with the request, and any parameters attached to it.
    * @return true if the {@link MutableSecondarySamplingState#samplingKey()} is sampled.
    */
-  boolean isSampled(MutableSecondarySamplingState state);
+  boolean isSampled(Object request, MutableSecondarySamplingState state);
 }

--- a/brave/src/test/java/brave/secondary_sampling/FakeRequest.java
+++ b/brave/src/test/java/brave/secondary_sampling/FakeRequest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.secondary_sampling;
+
+import brave.http.HttpClientRequest;
+import brave.http.HttpServerRequest;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class FakeRequest {
+  static final class Client extends HttpClientRequest {
+    Map<String, String> headers = new LinkedHashMap<>();
+
+    @Override public Object unwrap() {
+      return this;
+    }
+
+    @Override public String method() {
+      return null;
+    }
+
+    @Override public String path() {
+      return null;
+    }
+
+    @Override public String url() {
+      return null;
+    }
+
+    @Override public void header(String name, String value) {
+      headers.put(name, value);
+    }
+
+    @Override public String header(String name) {
+      return headers.get(name);
+    }
+  }
+
+  static final class Server extends HttpServerRequest {
+    Map<String, String> headers = new LinkedHashMap<>();
+
+    @Override public Object unwrap() {
+      return this;
+    }
+
+    @Override public String method() {
+      return null;
+    }
+
+    @Override public String path() {
+      return null;
+    }
+
+    @Override public String url() {
+      return null;
+    }
+
+    public void header(String name, String value) {
+      headers.put(name, value);
+    }
+
+    @Override public String header(String name) {
+      return headers.get(name);
+    }
+  }
+
+  private FakeRequest() {
+  }
+}

--- a/brave/src/test/java/brave/secondary_sampling/SecondarySamplingStateTest.java
+++ b/brave/src/test/java/brave/secondary_sampling/SecondarySamplingStateTest.java
@@ -51,7 +51,7 @@ public class SecondarySamplingStateTest {
   FakeRequest.Server serverRequest = new FakeRequest.Server();
 
   @Test public void extract_samplesLocalWhenConfigured() {
-    // base case: links is configured, authcache is not. authcache is in the serverRequest, though!
+    // base case: links is configured, authcache is not. authcache is in the sampling header, though!
     sampler.addTrigger("links", new Trigger());
 
     serverRequest.header("b3", "0");
@@ -82,7 +82,7 @@ public class SecondarySamplingStateTest {
 
   /** This shows an example of dynamic configuration */
   @Test public void dynamicConfiguration() {
-    // base case: links is configured, authcache is not. authcache is in the serverRequest, though!
+    // base case: links is configured, authcache is not. authcache is in the sampling header, though!
     sampler.addTrigger("links", new Trigger());
 
     serverRequest.header("b3", "0");

--- a/brave/src/test/java/brave/secondary_sampling/SecondarySamplingStateTest.java
+++ b/brave/src/test/java/brave/secondary_sampling/SecondarySamplingStateTest.java
@@ -13,6 +13,8 @@
  */
 package brave.secondary_sampling;
 
+import brave.http.HttpClientRequest;
+import brave.http.HttpServerRequest;
 import brave.propagation.B3SinglePropagation;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
@@ -21,8 +23,6 @@ import brave.propagation.TraceContext.Injector;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.secondary_sampling.SecondarySampling.Extra;
 import brave.secondary_sampling.TestSecondarySampler.Trigger;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.junit.Test;
 
 import static brave.propagation.Propagation.KeyFactory.STRING;
@@ -44,35 +44,36 @@ public class SecondarySamplingStateTest {
 
   Propagation<String> propagation = secondarySampling.create(STRING);
 
-  Extractor<Map<String, String>> extractor = propagation.extractor(Map::get);
-  Injector<Map<String, String>> injector = propagation.injector(Map::put);
+  Extractor<HttpServerRequest> extractor = propagation.extractor(HttpServerRequest::header);
+  Injector<HttpClientRequest> injector = propagation.injector(HttpClientRequest::header);
 
-  Map<String, String> headers = new LinkedHashMap<>();
+  FakeRequest.Client clientRequest = new FakeRequest.Client();
+  FakeRequest.Server serverRequest = new FakeRequest.Server();
 
   @Test public void extract_samplesLocalWhenConfigured() {
-    // base case: links is configured, authcache is not. authcache is in the headers, though!
+    // base case: links is configured, authcache is not. authcache is in the serverRequest, though!
     sampler.addTrigger("links", new Trigger());
 
-    headers.put("b3", "0");
-    headers.put("sampling", "authcache"); // sampling hint should not trigger
+    serverRequest.header("b3", "0");
+    serverRequest.header("sampling", "authcache"); // sampling hint should not trigger
 
-    assertThat(extractor.extract(headers).sampledLocal()).isFalse();
+    assertThat(extractor.extract(serverRequest).sampledLocal()).isFalse();
 
-    headers.put("b3", "0");
-    headers.put("sampling", "links,authcache;ttl=1"); // links should trigger
+    serverRequest.header("b3", "0");
+    serverRequest.header("sampling", "links,authcache;ttl=1"); // links should trigger
 
-    assertThat(extractor.extract(headers).sampledLocal()).isTrue();
+    assertThat(extractor.extract(serverRequest).sampledLocal()).isTrue();
   }
 
   /** This shows that TTL is applied regardless of sampler */
   @Test public void extract_ttlOverridesSampler() {
-    headers.put("b3", "0");
-    headers.put("sampling", "links,authcache;ttl=1");
+    serverRequest.header("b3", "0");
+    serverRequest.header("sampling", "links,authcache;ttl=1");
 
-    TraceContextOrSamplingFlags extracted = extractor.extract(headers);
+    TraceContextOrSamplingFlags extracted = extractor.extract(serverRequest);
+    Extra extra = (Extra) extracted.extra().get(0);
 
-    Map<SecondarySamplingState, Boolean> keyToState = ((Extra) extracted.extra().get(0)).toMap();
-    assertThat(keyToState)
+    assertThat(extra.toMap())
       // no TTL left for the next hop
       .containsEntry(SecondarySamplingState.create("authcache"), true)
       // not sampled because there's no trigger for links
@@ -81,21 +82,21 @@ public class SecondarySamplingStateTest {
 
   /** This shows an example of dynamic configuration */
   @Test public void dynamicConfiguration() {
-    // base case: links is configured, authcache is not. authcache is in the headers, though!
+    // base case: links is configured, authcache is not. authcache is in the serverRequest, though!
     sampler.addTrigger("links", new Trigger());
 
-    headers.put("b3", "0");
-    headers.put("sampling", "links,authcache");
+    serverRequest.header("b3", "0");
+    serverRequest.header("sampling", "links,authcache");
 
-    assertThat(extractor.extract(headers).sampledLocal()).isTrue();
+    assertThat(extractor.extract(serverRequest).sampledLocal()).isTrue();
 
     // dynamic configuration removes link processing
     sampler.removeTriggers("links");
-    assertThat(extractor.extract(headers).sampledLocal()).isFalse();
+    assertThat(extractor.extract(serverRequest).sampledLocal()).isFalse();
 
     // dynamic configuration adds authcache processing
     sampler.addTrigger("authcache", serviceName, new Trigger());
-    assertThat(extractor.extract(headers).sampledLocal()).isTrue();
+    assertThat(extractor.extract(serverRequest).sampledLocal()).isTrue();
   }
 
   @Test public void extract_convertsConfiguredRpsToDecision() {
@@ -103,13 +104,13 @@ public class SecondarySamplingStateTest {
     sampler.addTrigger("links", new Trigger());
     sampler.addTrigger("authcache", new Trigger().rps(100).ttl(1));
 
-    headers.put("b3", "0");
-    headers.put("sampling", "gatewayplay,links,authcache");
+    serverRequest.header("b3", "0");
+    serverRequest.header("sampling", "gatewayplay,links,authcache");
 
-    TraceContextOrSamplingFlags extracted = extractor.extract(headers);
+    TraceContextOrSamplingFlags extracted = extractor.extract(serverRequest);
+    Extra extra = (Extra) extracted.extra().get(0);
 
-    Map<SecondarySamplingState, Boolean> keyToState = ((Extra) extracted.extra().get(0)).toMap();
-    assertThat(keyToState).containsOnly(
+    assertThat(extra.toMap()).containsOnly(
       entry(SecondarySamplingState.create("links"), true),
       // authcache triggers a ttl
       entry(SecondarySamplingState.create(MutableSecondarySamplingState.create("authcache")
@@ -120,14 +121,13 @@ public class SecondarySamplingStateTest {
   }
 
   @Test public void extract_decrementsTtlEvenWhenNotConfigured() {
-    headers.put("b3", "0");
-    headers.put("sampling", "gatewayplay,authcache;ttl=2");
+    serverRequest.header("b3", "0");
+    serverRequest.header("sampling", "gatewayplay,authcache;ttl=2");
 
-    TraceContextOrSamplingFlags extracted = extractor.extract(headers);
+    TraceContextOrSamplingFlags extracted = extractor.extract(serverRequest);
     Extra extra = (Extra) extracted.extra().get(0);
 
-    Map<SecondarySamplingState, Boolean> keyToState = ((Extra) extracted.extra().get(0)).toMap();
-    assertThat(keyToState)
+    assertThat(extra.toMap())
       // not sampled due to config, rather from TTL: note it is decremented
       .containsEntry(SecondarySamplingState.create(MutableSecondarySamplingState.create("authcache")
         .parameter("ttl", "1")), true)
@@ -146,10 +146,10 @@ public class SecondarySamplingStateTest {
 
     TraceContext context = TraceContext.newBuilder()
       .traceId(1L).spanId(2L).sampled(false).extra(singletonList(extra)).build();
-    injector.inject(context, headers);
+    injector.inject(context, clientRequest);
 
     // doesn't interfere with keys not sampled.
-    assertThat(headers).containsEntry("sampling",
+    assertThat(clientRequest.header("sampling")).isEqualTo(
       "gatewayplay;spanId=" + notSpanId + ","
         + "links;spanId=" + context.spanIdString() + ","
         + "authcache;ttl=1;spanId=" + notSpanId);

--- a/brave/src/test/java/brave/secondary_sampling/TestSecondarySampler.java
+++ b/brave/src/test/java/brave/secondary_sampling/TestSecondarySampler.java
@@ -42,7 +42,7 @@ public final class TestSecondarySampler {
 
     public Trigger rps(String path, int rps) {
       this.sampler = HttpRuleSampler.newBuilder()
-        .addRule(null, path, rps)
+        .addRuleWithRate(null, path, rps)
         .build();
       return this;
     }

--- a/brave/src/test/java/brave/secondary_sampling/TestSecondarySampler.java
+++ b/brave/src/test/java/brave/secondary_sampling/TestSecondarySampler.java
@@ -13,6 +13,9 @@
  */
 package brave.secondary_sampling;
 
+import brave.http.HttpRequestSampler;
+import brave.http.HttpRuleSampler;
+import brave.http.HttpServerRequest;
 import brave.sampler.RateLimitingSampler;
 import brave.sampler.Sampler;
 import java.util.LinkedHashMap;
@@ -28,11 +31,19 @@ public final class TestSecondarySampler {
     }
 
     Mode mode = Mode.ACTIVE;
-    Sampler sampler = Sampler.ALWAYS_SAMPLE;
+    HttpRequestSampler sampler = HttpRequestSampler.ALWAYS_SAMPLE;
     int ttl = 0; // zero means don't add ttl
 
     public Trigger rps(int rps) {
-      this.sampler = RateLimitingSampler.create(rps);
+      Sampler rateLimiter = RateLimitingSampler.create(rps);
+      this.sampler = httpRequest -> rateLimiter.isSampled(0L);
+      return this;
+    }
+
+    public Trigger rps(String path, int rps) {
+      this.sampler = HttpRuleSampler.newBuilder()
+        .addRule(null, path, rps)
+        .build();
       return this;
     }
 
@@ -46,8 +57,9 @@ public final class TestSecondarySampler {
       return this;
     }
 
-    public boolean isSampled() {
-      return sampler.isSampled(0L);
+    public boolean isSampled(Object request) {
+      if (!(request instanceof HttpServerRequest)) return false; // only sample server side
+      return Boolean.TRUE.equals(sampler.trySample((HttpServerRequest) request));
     }
 
     public int ttl() {
@@ -65,7 +77,7 @@ public final class TestSecondarySampler {
   }
 
   public SecondarySampler forService(String serviceName) {
-    return (state) -> {
+    return (request, state) -> {
       Trigger trigger = getByService(state.samplingKey()).get(serviceName);
       if (trigger == null) trigger = allServices.get(state.samplingKey());
       if (trigger == null) return false;
@@ -76,7 +88,7 @@ public final class TestSecondarySampler {
         return state.parameter("spanId") != null;
       }
 
-      boolean sampled = trigger.isSampled();
+      boolean sampled = trigger.isSampled(request);
       if (sampled) state.ttl(trigger.ttl()); // Set any TTL
       return sampled;
     };

--- a/brave/src/test/java/brave/secondary_sampling/integration/SecondarySamplingIntegratedTest.java
+++ b/brave/src/test/java/brave/secondary_sampling/integration/SecondarySamplingIntegratedTest.java
@@ -53,7 +53,7 @@ public class SecondarySamplingIntegratedTest {
   Propagation.Factory b3 = B3SinglePropagation.FACTORY;
 
   TestSecondarySampler gatewayplaySampler = new TestSecondarySampler()
-    .addTrigger("gatewayplay", "gateway", new Trigger().rps(50))
+    .addTrigger("gatewayplay", "gateway", new Trigger().rps("/play", 50))
     .addTrigger("gatewayplay", "playback", new Trigger().mode(PASSIVE));
 
   TestSecondarySampler authcacheSampler = new TestSecondarySampler()
@@ -187,15 +187,9 @@ public class SecondarySamplingIntegratedTest {
     );
     assertThat(authcache.getDependencies()).isEmpty();
 
-    int gatewayplayTraceCount = gatewayplay.getTraces().size();
-    // TODO: Add request-based parameters so that we only sample when sending to /play
-    // Right now, the test implementation only looks at service name, so also reports
-    // gateway -> /recommend
-    assertThat(gatewayplayTraceCount).isEqualTo(2);
-
     // Hit playback directly as opposed to via the gateway. This should not increase the trace count
     serviceRoot.findDownStream("playback").execute("/play", headers);
-    assertThat(gatewayplay.getTraces()).hasSize(gatewayplayTraceCount);
+    assertThat(gatewayplay.getTraces()).hasSize(1);
   }
 
   @Test public void gatewayplay_b3_sampled() {

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <!-- This allows you to test feature branches with jitpack -->
     <brave.groupId>com.github.openzipkin.brave</brave.groupId>
-    <brave.version>master-SNAPSHOT</brave.version>
+    <brave.version>request-sampler-SNAPSHOT</brave.version>
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <!-- This allows you to test feature branches with jitpack -->
     <brave.groupId>com.github.openzipkin.brave</brave.groupId>
-    <brave.version>request-sampler-SNAPSHOT</brave.version>
+    <brave.version>master-SNAPSHOT</brave.version>
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />


### PR DESCRIPTION
This re-uses the new HttpRequestSampler from https://github.com/openzipkin/brave/pull/994

In doing so, we fix the ambiguity of one of our integration tests, which
formerly accidentally sampled an irrelevant path.