### PR TITLE
Consolidates HTTP and RPC sampling into the same policy

### DIFF
--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -43,6 +43,11 @@
 
     <dependency>
       <groupId>${brave.groupId}</groupId>
+      <artifactId>brave-instrumentation-rpc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${brave.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
       <scope>test</scope>
     </dependency>

--- a/brave/src/test/java/brave/secondary_sampling/FakeHttpRequest.java
+++ b/brave/src/test/java/brave/secondary_sampling/FakeHttpRequest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.secondary_sampling;
+
+import brave.http.HttpClientRequest;
+import brave.http.HttpServerRequest;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class FakeHttpRequest {
+  public static final class Client extends HttpClientRequest {
+    final String path;
+    final Map<String, String> headers = new LinkedHashMap<>();
+
+    public Client(String path) {
+      this.path = path;
+    }
+
+    @Override public Object unwrap() {
+      return this;
+    }
+
+    @Override public String method() {
+      return "GET";
+    }
+
+    @Override public String path() {
+      return path;
+    }
+
+    @Override public String url() {
+      return null;
+    }
+
+    @Override public void header(String name, String value) {
+      headers.put(name, value);
+    }
+
+    @Override public String header(String name) {
+      return headers.get(name);
+    }
+  }
+
+  public static final class Server extends HttpServerRequest {
+    final String path;
+    final Map<String, String> headers;
+
+    public Server(Client incoming) {
+      this.path = incoming.path;
+      this.headers = new LinkedHashMap<>(incoming.headers);
+    }
+
+    @Override public Object unwrap() {
+      return this;
+    }
+
+    @Override public String method() {
+      return "GET";
+    }
+
+    @Override public String path() {
+      return path;
+    }
+
+    @Override public String url() {
+      return null;
+    }
+
+    public void header(String name, String value) {
+      headers.put(name, value);
+    }
+
+    @Override public String header(String name) {
+      return headers.get(name);
+    }
+  }
+
+  private FakeHttpRequest() {
+  }
+}

--- a/brave/src/test/java/brave/secondary_sampling/FakeHttpResponse.java
+++ b/brave/src/test/java/brave/secondary_sampling/FakeHttpResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.secondary_sampling;
+
+import brave.http.HttpClientResponse;
+import brave.http.HttpServerResponse;
+
+public final class FakeHttpResponse {
+  public static final class Client extends HttpClientResponse {
+    @Override public Object unwrap() {
+      return this;
+    }
+
+    @Override public int statusCode() {
+      return 200;
+    }
+  }
+
+  public static final class Server extends HttpServerResponse {
+    @Override public Object unwrap() {
+      return this;
+    }
+
+    @Override public int statusCode() {
+      return 200;
+    }
+  }
+
+  private FakeHttpResponse() {
+  }
+}

--- a/brave/src/test/java/brave/secondary_sampling/FakeRpcRequest.java
+++ b/brave/src/test/java/brave/secondary_sampling/FakeRpcRequest.java
@@ -13,68 +13,71 @@
  */
 package brave.secondary_sampling;
 
-import brave.http.HttpClientRequest;
-import brave.http.HttpServerRequest;
+import brave.rpc.RpcClientRequest;
+import brave.rpc.RpcServerRequest;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-final class FakeRequest {
-  static final class Client extends HttpClientRequest {
-    Map<String, String> headers = new LinkedHashMap<>();
+public final class FakeRpcRequest {
+  public static final class Client extends RpcClientRequest {
+    final String method;
+    final Map<String, String> headers = new LinkedHashMap<>();
+
+    public Client(String method) {
+      this.method = method;
+    }
 
     @Override public Object unwrap() {
       return this;
     }
 
-    @Override public String method() {
+    @Override public String service() {
       return null;
-    }
-
-    @Override public String path() {
-      return "/";
-    }
-
-    @Override public String url() {
-      return null;
-    }
-
-    @Override public void header(String name, String value) {
-      headers.put(name, value);
-    }
-
-    @Override public String header(String name) {
-      return headers.get(name);
-    }
-  }
-
-  static final class Server extends HttpServerRequest {
-    Map<String, String> headers = new LinkedHashMap<>();
-
-    @Override public Object unwrap() {
-      return this;
     }
 
     @Override public String method() {
-      return null;
-    }
-
-    @Override public String path() {
-      return "/";
-    }
-
-    @Override public String url() {
-      return null;
+      return method;
     }
 
     public void header(String name, String value) {
       headers.put(name, value);
     }
 
-    @Override public String header(String name) {
+    public String header(String name) {
       return headers.get(name);
     }
   }
 
-  private FakeRequest() {
+  public static final class Server extends RpcServerRequest {
+    final String method;
+    final Map<String, String> headers;
+
+    public Server(Client incoming) {
+      this.method = incoming.method;
+      this.headers = new LinkedHashMap<>(incoming.headers);
+    }
+
+    @Override public Object unwrap() {
+      return this;
+    }
+
+    @Override public String service() {
+      return method;
+    }
+
+    @Override public String method() {
+      return method;
+    }
+
+    public void header(String name, String value) {
+      headers.put(name, value);
+    }
+
+    public String header(String name) {
+      return headers.get(name);
+    }
+  }
+
+  private FakeRpcRequest() {
   }
 }

--- a/brave/src/test/java/brave/secondary_sampling/SecondarySamplingTest.java
+++ b/brave/src/test/java/brave/secondary_sampling/SecondarySamplingTest.java
@@ -41,38 +41,39 @@ public class SecondarySamplingTest {
   SecondarySampling secondarySampling = SecondarySampling.newBuilder()
     .propagationFactory(B3SinglePropagation.FACTORY)
     .httpServerSampler(sampler.primaryHttpSampler(serviceName))
+    .rpcServerSampler(sampler.primaryRpcSampler(serviceName))
     .secondarySampler(sampler.secondarySampler(serviceName))
     .build();
 
   Propagation<String> propagation = secondarySampling.create(STRING);
 
-  Extractor<HttpServerRequest> extractor = propagation.extractor(HttpServerRequest::header);
-  Injector<HttpClientRequest> injector = propagation.injector(HttpClientRequest::header);
+  Extractor<HttpServerRequest> httpExtractor = propagation.extractor(HttpServerRequest::header);
+  Injector<HttpClientRequest> httpInjector = propagation.injector(HttpClientRequest::header);
 
-  FakeRequest.Client clientRequest = new FakeRequest.Client();
-  FakeRequest.Server serverRequest = new FakeRequest.Server();
+  FakeHttpRequest.Client clientHttpRequest = new FakeHttpRequest.Client("/play");
+  FakeHttpRequest.Server serverHttpRequest = new FakeHttpRequest.Server(clientHttpRequest);
 
   @Test public void extract_samplesLocalWhenConfigured() {
     // base case: links is configured, authcache is not. authcache is in the serverRequest, though!
     sampler.putSecondaryRule("links", active());
 
-    serverRequest.header("b3", "0");
-    serverRequest.header("sampling", "authcache"); // sampling hint should not trigger
+    serverHttpRequest.header("b3", "0");
+    serverHttpRequest.header("sampling", "authcache"); // sampling hint should not trigger
 
-    assertThat(extractor.extract(serverRequest).sampledLocal()).isFalse();
+    assertThat(httpExtractor.extract(serverHttpRequest).sampledLocal()).isFalse();
 
-    serverRequest.header("b3", "0");
-    serverRequest.header("sampling", "links,authcache;ttl=1"); // links should trigger
+    serverHttpRequest.header("b3", "0");
+    serverHttpRequest.header("sampling", "links,authcache;ttl=1"); // links should trigger
 
-    assertThat(extractor.extract(serverRequest).sampledLocal()).isTrue();
+    assertThat(httpExtractor.extract(serverHttpRequest).sampledLocal()).isTrue();
   }
 
   /** This shows that TTL is applied regardless of sampler */
   @Test public void extract_ttlOverridesSampler() {
-    serverRequest.header("b3", "0");
-    serverRequest.header("sampling", "links,authcache;ttl=1");
+    serverHttpRequest.header("b3", "0");
+    serverHttpRequest.header("sampling", "links,authcache;ttl=1");
 
-    TraceContextOrSamplingFlags extracted = extractor.extract(serverRequest);
+    TraceContextOrSamplingFlags extracted = httpExtractor.extract(serverHttpRequest);
     Extra extra = (Extra) extracted.extra().get(0);
 
     assertThat(extra.toMap())
@@ -87,18 +88,18 @@ public class SecondarySamplingTest {
     // base case: links is configured, authcache is not. authcache is in the serverRequest, though!
     sampler.putSecondaryRule("links", active());
 
-    serverRequest.header("b3", "0");
-    serverRequest.header("sampling", "links,authcache");
+    serverHttpRequest.header("b3", "0");
+    serverHttpRequest.header("sampling", "links,authcache");
 
-    assertThat(extractor.extract(serverRequest).sampledLocal()).isTrue();
+    assertThat(httpExtractor.extract(serverHttpRequest).sampledLocal()).isTrue();
 
     // dynamic configuration removes link processing
     sampler.removeSecondaryRules("links");
-    assertThat(extractor.extract(serverRequest).sampledLocal()).isFalse();
+    assertThat(httpExtractor.extract(serverHttpRequest).sampledLocal()).isFalse();
 
     // dynamic configuration adds authcache processing
     sampler.putSecondaryRule(serviceName, "authcache", active());
-    assertThat(extractor.extract(serverRequest).sampledLocal()).isTrue();
+    assertThat(httpExtractor.extract(serverHttpRequest).sampledLocal()).isTrue();
   }
 
   @Test public void extract_convertsConfiguredRpsToDecision() {
@@ -106,10 +107,10 @@ public class SecondarySamplingTest {
     sampler.putSecondaryRule("links", active());
     sampler.putSecondaryRule("authcache", active(RateLimitingSampler.create(100), 1));
 
-    serverRequest.header("b3", "0");
-    serverRequest.header("sampling", "gatewayplay,links,authcache");
+    serverHttpRequest.header("b3", "0");
+    serverHttpRequest.header("sampling", "gatewayplay,links,authcache");
 
-    TraceContextOrSamplingFlags extracted = extractor.extract(serverRequest);
+    TraceContextOrSamplingFlags extracted = httpExtractor.extract(serverHttpRequest);
     Extra extra = (Extra) extracted.extra().get(0);
 
     assertThat(extra.toMap()).containsOnly(
@@ -123,10 +124,10 @@ public class SecondarySamplingTest {
   }
 
   @Test public void extract_decrementsTtlEvenWhenNotConfigured() {
-    serverRequest.header("b3", "0");
-    serverRequest.header("sampling", "gatewayplay,authcache;ttl=2");
+    serverHttpRequest.header("b3", "0");
+    serverHttpRequest.header("sampling", "gatewayplay,authcache;ttl=2");
 
-    TraceContextOrSamplingFlags extracted = extractor.extract(serverRequest);
+    TraceContextOrSamplingFlags extracted = httpExtractor.extract(serverHttpRequest);
     Extra extra = (Extra) extracted.extra().get(0);
 
     assertThat(extra.toMap())
@@ -148,10 +149,10 @@ public class SecondarySamplingTest {
 
     TraceContext context = TraceContext.newBuilder()
       .traceId(1L).spanId(2L).sampled(false).extra(singletonList(extra)).build();
-    injector.inject(context, clientRequest);
+    httpInjector.inject(context, clientHttpRequest);
 
     // doesn't interfere with keys not sampled.
-    assertThat(clientRequest.header("sampling")).isEqualTo(
+    assertThat(clientHttpRequest.header("sampling")).isEqualTo(
       "gatewayplay;spanId=" + notSpanId + ","
         + "links;spanId=" + context.spanIdString() + ","
         + "authcache;ttl=1;spanId=" + notSpanId);

--- a/brave/src/test/java/brave/unmerged/MoreMatchers.java
+++ b/brave/src/test/java/brave/unmerged/MoreMatchers.java
@@ -18,16 +18,37 @@ import brave.sampler.Matcher;
 public final class MoreMatchers {
   /**
    * This allows you to safely pass a type-specific matcher, guarded in the same fashion as if you
-   * called {@code parameters instance of P}.
+   * called {@code parameters instance of P}. This is the opposite of {@link #cast(Matcher)}.
    *
    * <p>Ex to ensure an HTTP matcher isn't invoked with the wrong type:
    * <pre>{@code
    * Matcher<Object> acceptsObject =
    *   ifInstanceOf(HttpRequest.class, HttpRequestMatchers.pathStartsWith(path));
    * }</pre>
+   *
+   * @see #cast(Matcher)
+   * @since 5.8
    */
   public static <P> Matcher<Object> ifInstanceOf(Class<P> paramType, Matcher<P> matcher) {
     return new IfInstanceOf(paramType, matcher);
+  }
+
+  /**
+   * This casts a matcher so that it matches a narrowed type. This is the opposite of {@link
+   * #ifInstanceOf(Class, Matcher)}.
+   *
+   * <p>For example, given a matcher of type Object, it is always safe to pass a subtype:
+   * <pre>{@code
+   * Matcher<Object> acceptsObject = ...
+   * Matcher<HttpRequest> acceptsHttpRequest = cast(acceptsObject);
+   * }</pre>
+   *
+   * @see #ifInstanceOf(Class, Matcher)
+   * @since 5.8
+   */
+  @SuppressWarnings("unchecked") // safe contravariant cast
+  public static <P> Matcher<P> cast(Matcher<Object> matcher) {
+    return (Matcher<P>) matcher;
   }
 
   static final class IfInstanceOf implements Matcher<Object> {

--- a/brave/src/test/java/brave/unmerged/MoreMatchersTest.java
+++ b/brave/src/test/java/brave/unmerged/MoreMatchersTest.java
@@ -31,6 +31,12 @@ public class MoreMatchersTest {
     assertThat(neverMatch().matches(null)).isFalse();
   }
 
+  @Test public void cast() {
+    Matcher<Object> matchesObject = o -> true;
+    Matcher<String> matchesString = MoreMatchers.cast(matchesObject);
+    assertThat(matchesString).isSameAs(matchesObject);
+  }
+
   @Test public void ifInstanceOf_matched() {
     Matcher<String> matchesString = v -> true;
     Matcher<Object> matchesObject = MoreMatchers.ifInstanceOf(String.class, matchesString);

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,10 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <!-- This allows you to test feature branches with jitpack -->
-    <brave.groupId>com.github.openzipkin.brave</brave.groupId>
-    <brave.version>master-SNAPSHOT</brave.version>
+<!--    <brave.groupId>com.github.openzipkin.brave</brave.groupId>-->
+<!--    <brave.version>master-SNAPSHOT</brave.version>-->
+    <brave.groupId>io.zipkin.brave</brave.groupId>
+    <brave.version>5.8.0</brave.version>
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
         <artifactId>brave-instrumentation-http-tests</artifactId>
         <version>${brave.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>${brave.groupId}</groupId>
+        <artifactId>brave-instrumentation-rpc</artifactId>
+        <version>${brave.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This proves that HTTP and RPC policy can co-exist by changing one of the
test nodes to a fake gRPC service.

For example, the following only matches when the auth service is an RPC
node and also when it has a specific RPC method:
```java
  SamplerController allSampler = new SamplerController.Default()
    .putSecondaryHttpRule("gateway", "gatewayplay",
      pathStartsWith("/play"), RateLimitingSampler.create(50)
    )
    .putSecondaryRule("playback", "gatewayplay",
      passive()
    )
    .putSecondaryRpcRule("auth", "authcache",
      methodEquals("GetToken"), RateLimitingSampler.create(100), 1 /* TTL */
    );
```

Fixes #11
Fixes #8