### PR TITLE
Adds a provisioning api

### DIFF
--- a/brave/RATIONALE.md
+++ b/brave/RATIONALE.md
@@ -1,0 +1,21 @@
+# brave-secondary-sampling rationale
+
+## `SecondaryProvisioner` overview
+
+`SecondaryProvisioner`'s job is to create new sampling key configuration. Without this,
+implementation can only participate in existing sampling keys: they cannot create new ones.
+
+### What happens if the sampling key being provisioned exists in incoming headers?
+It is possible that a sampling key the host wants to provision is also in headers. To write an Api
+that can see potentially pre-existing state is more complex. As it is expected that a local decision
+would override anyway, this implementation ignores any incoming state when the same key is
+provisioned locally.
+
+### Why not always sample new keys?
+Some sites will want to decentralize key provisioning, so every time they create a key, they will
+also sample it. For example, if such a site desires just data around the auth subsytem, the auth
+service itself would provision a key and also send data for it before propagating downstream.
+
+The converse could also be true. For example, existing Zipkin sites centralize policy in API
+gateways. In this case, the duty for provisioning secondary keys could also be centralized, even
+if the desired data is downstream.

--- a/brave/src/main/java/brave/secondary_sampling/MutableSecondarySamplingState.java
+++ b/brave/src/main/java/brave/secondary_sampling/MutableSecondarySamplingState.java
@@ -65,12 +65,14 @@ public final class MutableSecondarySamplingState {
 
   /** Retrieves the current TTL of this {@link #samplingKey()} or zero if there is none. */
   public int ttl() {
+    // TODO: add a limit to TTL, like 255 and make this and below super more efficient
     String ttl = parameter("ttl");
-    return ttl == null ? 0 : Integer.parseInt(ttl);
+    if (ttl == null || "0".equals(ttl) || ttl.startsWith("-")) return 0;
+    return Integer.parseInt(ttl); // TODO: when we make a limit, eliminate the parse exception
   }
 
   @Nullable public MutableSecondarySamplingState ttl(int ttl) {
-    if (ttl == 0) return removeParameter("ttl");
+    if (ttl <= 0) return removeParameter("ttl");
     return parameter("ttl", String.valueOf(ttl));
   }
 

--- a/brave/src/main/java/brave/secondary_sampling/SecondaryProvisioner.java
+++ b/brave/src/main/java/brave/secondary_sampling/SecondaryProvisioner.java
@@ -22,15 +22,6 @@ import brave.propagation.TraceContext;
  * <p>Each invocation of the {@link SecondaryProvisioner.Callback} will provision a new key. When
  * that key is sampled, is means the node provisioning is also participating. When it is not
  * sampled, the node is just passing a key downstream for another to sample.
- *
- * <h3>Why not always sample new keys?</h3>
- * Some sites will want to decentralize key provisioning, so every time they create a key, they will
- * also sample it. For example, if such a site desires just data around the auth subsytem, the auth
- * service itself would provision a key and also send data for it before propagating downstream.
- *
- * <p>The converse could also be true. For example, existing Zipkin sites centralize policy in API
- * gateways. In this case, the duty for provisioning secondary keys could also be centralized, even
- * if the desired data is downstream.
  */
 public interface SecondaryProvisioner {
   interface Callback {

--- a/brave/src/main/java/brave/secondary_sampling/SecondaryProvisioner.java
+++ b/brave/src/main/java/brave/secondary_sampling/SecondaryProvisioner.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.secondary_sampling;
+
+import brave.propagation.TraceContext;
+
+/**
+ * An implementation of this will apply policy to provision new sampling keys based on an incoming
+ * request. All sampling keys provisioned will not be invoked with {@link SecondarySampler}.
+ *
+ * <p>Each invocation of the {@link SecondaryProvisioner.Callback} will provision a new key. When
+ * that key is sampled, is means the node provisioning is also participating. When it is not
+ * sampled, the node is just passing a key downstream for another to sample.
+ *
+ * <h3>Why not always sample new keys?</h3>
+ * Some sites will want to decentralize key provisioning, so every time they create a key, they will
+ * also sample it. For example, if such a site desires just data around the auth subsytem, the auth
+ * service itself would provision a key and also send data for it before propagating downstream.
+ *
+ * <p>The converse could also be true. For example, existing Zipkin sites centralize policy in API
+ * gateways. In this case, the duty for provisioning secondary keys could also be centralized, even
+ * if the desired data is downstream.
+ */
+public interface SecondaryProvisioner {
+  interface Callback {
+    /**
+     * This adds a new {@link SecondarySamplingState#samplingKey() sampling key}.
+     *
+     * <p>If {@code sampled}, the resulting trace context will be {@link
+     * TraceContext#sampledLocal()} for this node. Otherwise, the state is propagated downstream for
+     * a later node to sample.
+     *
+     * <p>Only the first call for the same {@link SecondarySamplingState#samplingKey() sampling
+     * key} is honored. Any redundant calls will be logged and ignored.
+     */
+    void addSamplingState(SecondarySamplingState state, boolean sampled);
+  }
+
+  /**
+   * This parses a request and provisions any relevant sampling keys using the passed callback.
+   *
+   * <p>Here's an example where the current node provisions a key named "play" and also
+   * participates in it. This results in data collected here and also downstream nodes that {@link
+   * SecondarySampler sample} the key.
+   * <pre>{@code
+   * if (request instanceof HttpServerRequest) {
+   *   HttpServerRequest serverRequest = (HttpServerRequest) request;
+   *    if (serverRequest.path().startsWith("/play")) {
+   *      callback.addSamplingState(SecondarySamplingState.create("play"), true);
+   *    }
+   * }
+   * }</pre>
+   */
+  void provision(Object request, Callback callback);
+}

--- a/brave/src/main/java/brave/secondary_sampling/SecondarySamplingExtractor.java
+++ b/brave/src/main/java/brave/secondary_sampling/SecondarySamplingExtractor.java
@@ -16,6 +16,7 @@ package brave.secondary_sampling;
 import brave.propagation.Propagation.Getter;
 import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContextOrSamplingFlags;
+import java.util.LinkedHashMap;
 
 import static brave.secondary_sampling.SecondarySampling.EXTRA_FACTORY;
 
@@ -27,12 +28,14 @@ import static brave.secondary_sampling.SecondarySampling.EXTRA_FACTORY;
 final class SecondarySamplingExtractor<C, K> implements Extractor<C> {
   final Extractor<C> delegate;
   final Getter<C, K> getter;
+  final SecondaryProvisioner provisioner;
   final SecondarySampler sampler;
   final K samplingKey;
 
   SecondarySamplingExtractor(SecondarySampling.Propagation<K> propagation, Getter<C, K> getter) {
     this.delegate = propagation.delegate.extractor(getter);
     this.getter = getter;
+    this.provisioner = propagation.secondarySampling.provisioner;
     this.sampler = propagation.secondarySampling.secondarySampler;
     this.samplingKey = propagation.samplingKey;
   }
@@ -42,21 +45,33 @@ final class SecondarySamplingExtractor<C, K> implements Extractor<C> {
     String maybeValue = getter.get(request, samplingKey);
     if (maybeValue == null) return result;
 
-    SecondarySampling.Extra extra = EXTRA_FACTORY.create();
-    boolean sampledLocal = false;
+    SampledLocalMap initial = new SampledLocalMap();
+    provisioner.provision(request, initial);
     for (String entry : maybeValue.split(",", 100)) {
       MutableSecondarySamplingState state = MutableSecondarySamplingState.parse(entry);
       boolean sampled = updateStateAndSample(request, state);
-      if (sampled) sampledLocal = true;
-      extra.put(SecondarySamplingState.create(state), sampled);
+      initial.addSamplingState(SecondarySamplingState.create(state), sampled);
     }
 
-    if (extra.isEmpty()) return result;
-
+    SecondarySampling.Extra extra = EXTRA_FACTORY.create(initial);
     TraceContextOrSamplingFlags.Builder builder = result.toBuilder();
-    if (sampledLocal) builder.sampledLocal(); // Data will be recorded even if B3 unsampled
+    if (initial.sampledLocal) builder.sampledLocal(); // Data will be recorded even if B3 unsampled
     builder.addExtra(extra);
     return builder.build();
+  }
+
+  final class SampledLocalMap extends LinkedHashMap<SecondarySamplingState, Boolean>
+    implements SecondaryProvisioner.Callback {
+    boolean sampledLocal = false;
+
+    @Override public void addSamplingState(SecondarySamplingState state, boolean sampled) {
+      if (containsKey(state)) {
+        // redundant: log and continue
+        return;
+      }
+      if (sampled) sampledLocal = true;
+      put(state, sampled);
+    }
   }
 
   boolean updateStateAndSample(Object request, MutableSecondarySamplingState state) {

--- a/brave/src/test/java/brave/secondary_sampling/MutableSecondarySamplingStateTest.java
+++ b/brave/src/test/java/brave/secondary_sampling/MutableSecondarySamplingStateTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.secondary_sampling;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MutableSecondarySamplingStateTest {
+  @Test public void parse_ttl() {
+    assertThat(MutableSecondarySamplingState.parse("authcache;ttl=-1").ttl()).isZero();
+    assertThat(MutableSecondarySamplingState.parse("authcache;ttl=0").ttl()).isZero();
+    assertThat(MutableSecondarySamplingState.parse("authcache;ttl=2").ttl()).isEqualTo(2);
+  }
+}

--- a/brave/src/test/java/brave/secondary_sampling/SamplerController.java
+++ b/brave/src/test/java/brave/secondary_sampling/SamplerController.java
@@ -131,7 +131,7 @@ public interface SamplerController {
 
     @Override public SecondaryProvisioner secondaryProvisioner(String serviceName) {
       return (request, callback) -> {
-        provisioners.get(serviceName).provision(request, callback);
+        provisioners.getOrDefault(serviceName, (r, c) -> {}).provision(request, callback);
       };
     }
 

--- a/brave/src/test/java/brave/secondary_sampling/SecondarySamplingProvisionerTest.java
+++ b/brave/src/test/java/brave/secondary_sampling/SecondarySamplingProvisionerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.secondary_sampling;
+
+import brave.http.HttpServerRequest;
+import brave.propagation.B3SinglePropagation;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext.Extractor;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.secondary_sampling.SecondarySampling.Extra;
+import org.junit.Test;
+
+import static brave.propagation.Propagation.KeyFactory.STRING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecondarySamplingProvisionerTest {
+  String serviceName = "license";
+  SamplerController sampler = new SamplerController.Default();
+  SecondarySampling secondarySampling = SecondarySampling.newBuilder()
+    .propagationFactory(B3SinglePropagation.FACTORY)
+    .secondarySampler(sampler.secondarySampler(serviceName))
+    .provisioner(sampler.secondaryProvisioner(serviceName))
+    .build();
+
+  Propagation<String> propagation = secondarySampling.create(STRING);
+
+  Extractor<HttpServerRequest> httpExtractor = propagation.extractor(HttpServerRequest::header);
+
+  FakeHttpRequest.Client clientHttpRequest = new FakeHttpRequest.Client("/validateLicense");
+  FakeHttpRequest.Server serverHttpRequest = new FakeHttpRequest.Server(clientHttpRequest);
+
+  @Test public void extract_samplesLocalWhenProvisioned() {
+    sampler.putProvisioner(serviceName, (request, callback) -> callback.addSamplingState(
+      SecondarySamplingState.create(
+        MutableSecondarySamplingState.create("license100pct")),
+      true
+    ));
+
+    TraceContextOrSamplingFlags extracted = httpExtractor.extract(serverHttpRequest);
+    assertThat(extracted.sampledLocal()).isTrue();
+
+    Extra extra = (Extra) extracted.extra().get(0);
+    assertThat(extra.toMap())
+      .containsEntry(SecondarySamplingState.create("license100pct"), true);
+  }
+
+}

--- a/brave/src/test/java/brave/secondary_sampling/integration/SecondarySamplingIntegratedTest.java
+++ b/brave/src/test/java/brave/secondary_sampling/integration/SecondarySamplingIntegratedTest.java
@@ -18,8 +18,12 @@ import brave.propagation.B3SinglePropagation;
 import brave.propagation.Propagation;
 import brave.sampler.RateLimitingSampler;
 import brave.sampler.Sampler;
-import brave.secondary_sampling.*;
-
+import brave.secondary_sampling.FakeHttpRequest;
+import brave.secondary_sampling.MutableSecondarySamplingState;
+import brave.secondary_sampling.SamplerController;
+import brave.secondary_sampling.SecondarySampling;
+import brave.secondary_sampling.SecondarySamplingState;
+import brave.secondary_sampling.TraceForwarder;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;

--- a/brave/src/test/java/brave/secondary_sampling/integration/TracedNode.java
+++ b/brave/src/test/java/brave/secondary_sampling/integration/TracedNode.java
@@ -231,4 +231,9 @@ class TracedNode {
     span.kind(Span.Kind.SERVER).name(serverRequest.method());
     return span.start();
   }
+
+  @Override
+  public String toString() {
+    return localServiceName;
+  }
 }


### PR DESCRIPTION
This adds `SecondaryProvisioner` which can add one or more sampling keys, and optionally sample locally if the same node is participating.

Fixes #10