### PR TITLE
Adds publication setup for bintray

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar

--- a/.settings.xml
+++ b/.settings.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2019 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>sonatype</id>
+      <username>${env.SONATYPE_USER}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>bintray</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_KEY}</password>
+    </server>
+    <server>
+      <id>jfrog-snapshots</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_KEY}</password>
+    </server>
+    <server>
+      <id>github.com</id>
+      <username>zipkinci</username>
+      <password>${env.GH_TOKEN}</password>
+    </server>
+  </servers>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,42 @@ language: java
 
 jdk: openjdk11
 
+before_install:
+  # allocate commits to CI, not the owner of the deploy key
+  - git config user.name "zipkinci"
+  - git config user.email "zipkinci+zipkin-dev@googlegroups.com"
+  # setup https authentication credentials, used by ./mvnw release:prepare
+  - git config credential.helper "store --file=.git/credentials"
+  - echo "https://$GH_TOKEN:@github.com" > .git/credentials
+
 # Override default travis to use the maven wrapper; skip license on travis due to #1512
-install: ./mvnw verify -Dlicense.skip=true -B
+install: ./mvnw install -Dlicense.skip=true -Dmaven.javadoc.skip=true -B -V
+
+script: ./travis/publish.sh
+# Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.
+# See https://github.com/travis-ci/travis-ci/issues/1532
+branches:
+  except:
+    - /^[0-9]/
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/ead3c37d57527214e9f2
+      - https://webhooks.gitter.im/e/e57478303f87ecd7bffc
+    on_success: change
+    on_failure: always
+
+env:
+  global:
+    # Ex. travis encrypt BINTRAY_USER=your_github_account
+    - secure: "b/12qlIYpraAmiqQiiCUDGHrL7cmuPCPc3oSFiLlDiqetTxgG7M8tal0BRpHrP3UWHdNfF0aCzgQSzQ342xhRJsvPH6BahUXIhKBSxjq+iA2I0/bFphvFjmLuqU3vjT3F4kaomd4zwNaMflD4zI6/VRQDe5Y3BGN39biiM93vTMYGuzdLp0c8xFO4GpxA2IyX7DJpmHkf5umIQ7tCJVPRJUF1Kzo+PgM4JI+NuixrlqpF9Pnte/axEkK25UGpql4Ssl1DQEwXsE2ZU0Fn5rAOYiI2hqyTkQ/1Q5Yw4tOKDcjUQYefv1vHambNhIos3pvLhQzAQwdDp/Z2NZV3FhIDrFFIyaXmXo3PcbX/4I274NXO8dVj0lR5edbbq2Q2WTXb8S8LJbdA/4pkcvenwTXTUCWP9rqImXs8XwoxjcAc8lgVV8bPd6T6idNY2PYlhUDkzEPAMU2BZEYK2sSGS94lpAellxRYAbDcHWE7gircj6baWP8aoULilBGaVTMwGRpVksURhWZ6QRNQWpMcAMZXq2rcEEbL1L1mQFV0Y9WVk614m/8/i2DyXX5w6hXjAp7qobWK4CQg/DFx6lfUcGmYgE9sqVChgWDyUwMAXsmalUp7z5opiR1nBbwfetRC2xbFdsWGwCzR84bsXwNaM83Q99UdGm2HLUWMQTvRpiXG50="
+    # Ex. travis encrypt BINTRAY_KEY=xxx-https://bintray.com/profile/edit-xxx --add
+    - secure: "XTmslsGYBudNBKTTIkF5d3JI7j2ZxMMeOw2/L1U+AuMAE3GGy3hSFsjnrXQC+dhdOkNmVwrsoC6Fa9Hk2J+7pXUUec4aJWd/cy+NVkrU7EgylYNndWRpyIwpY0JvCiAdUEMCWXgp2DCyoxdyACB3c+9iAlVYuHS5ug2E/S/gwhAkXef6B7YZ4GjKjTKKT3iBf+0S9LxeQYJZOb//XReufdCLwwXnhw9CpGwqNJq2nh9JhgEtLFaWaEOqKdlgiMngXdWqglCmdKokt4NuxCpQlb0T3T/bbNZBoa/K95Y5kJZoRj+sCSqt8ajsFiJH7unnF5y0qT09GStDsxY480GagfE4gxPoyR91TOCBUw5m18B/36nqvd1l1R8qXqsjw6Eee+loZebRGphZ/sse0nOA0dStNDg+RudGN4mvoGq6CsrX8bikndtfbBb/YgCODGHahK1c3OYXnmrG/xZaRe5tHMCfv6ymyEbHU0IOBxtR6m4yFH4c0mktcZVL20Tt2C9miaeXS+9/NMqSo7sIlX+BLpxsHi/t+aYwlpNpQvPQnBh9hP4AuCuQGYgQsor1cZBb3XFDT9IoVrAEFqec0sfc5GiTF0jDcgP8ME5qCsUXFRfFOstWgLO5UhPWdhCnSL1+j3rWhMmI91Kc5B4AmL2BiYhl9lSkHUaZAeKCZuZdttQ="
+    # Ex. travis encrypt GH_TOKEN=XXX-https://github.com/settings/tokens-XXX --add
+    - secure: "U8Xul+Mj5kTFfsNNV+jW/+CUPREku63k5w9R9OaVGtfHXf4ytxHoRL4LwUtVMzfB/TdHuiujBhUz4/zOvq8q+Ra2HJh83hqepg/7lH/aeb3XYMU1GHdts89GHOOaZcTzYaI3GxdxZVBYN9EplT06PQqMXUMZv55YDzFST2fbsaQ407MvzvdlGwygV8dA9PQtuUVKzc0WVklxkDYxpep9BThj3by2LRXkaeaZnQsypv9LUeAYXIsDvzSsTmAqn9/I6twT+ocErWGGUuFiMUcO1T6CKnNRi0rX4mvXsbF+7HUPZBPApExpbG7b85KAW9nL82T+mKJ1lKWnnLtzmMS4xcTbDFX/imeccCRiRNt1HdRHqRimDl/6EUzNABhtyHYQI/jB4jBppfB+4KYolcPj1Xci5M24Pv/zIWcwJosVrtOfnF1LAD835X1kqU45YJbFDyeK29K0UefXhGRYq1t9SDuX+WLgWb7HmE8olyj5hreCXHZx9LWoglJkURII9mXlOOfMz9MAoPF9rqDPxbfMfcr1x3m5u39ZXQ5W4znYKVBNWAu71kgxAnrQ8G/OgvUqdTgGty1meLe5DfNpaC5iy67NToAUjNeFjkAfo4Fz6SC7b83343CgG5YEmvlAQr6ZzY6IA89l0VCH/3MhYPJQ1esF6Kq6VywpU+nJiVsiz2Y="
+    # Ex. travis encrypt SONATYPE_USER=your_sonatype_account
+    - secure: "tbzQ9cRFbOJhnuFRJAGbx10DxyW3jH4ogbe5JNTx8VfdAmAplgV5g91OGE2PjFeIQAwroB+2DpNQ+t0UTylDLEDIPrS5QMWQiXMUI/LP4dGzSla2lNjl8dbbgXRkGMuCLZuunmOiFURgtmZLyPzX0ALJvC68TGg9WxA7FUZh1Z+lwUTB7e88UMwsgxqYGmDqVCJfBPC9REnK+MoQVGdlv6kj87cSPOx0WUETvDiHO4Z3E6MbgjORxF/9jGX2PuUwKbm0VDpxohN9SYD2bD6JQKJ6P8xIwC92xMbR6ndg1DQ20o9KRIqaCAk6aLpk0aKRcih+YlhZXYe2AfKhRmezEI6G6gljiRRKHESyJHtCgbheyfcKAbBAxmMmQmImRJK5+7QgOam0mKwKXeE4Pml7mNk68Pq5Kgt/eF8oYH9uHeYXE9AIYBmi2HSQsohBhgrHX9t3Zb/fahAc2XtOEvG7of46fV8Mqbhn7PfEwvVMx4+3dHOZlI2PEmOgC93E/CFIKps1hzbcU5Ki+vRjFtKOg36NpuM/ePaFMhLs06KKd1p1xLGysocs7k1eT9jyti514AO50z/QQpjw+eNOvl/NXyFSC/MtbDSYrtTDPwHCuMZpNI9nK2ozMap3UFac/jerg5oZ8Iu5oAU9hA7VewlGFsTSNJ/DjeL0rvPIhpfo99M="
+    # Ex. travis encrypt SONATYPE_PASSWORD=your_sonatype_password
+    - secure: "nEaT4J3F3s7ERpy3lW6g9KkrMgjX9vxzfc4KlUSq1PC+70n9w62zGsoFQJOjA9psBrKzkOik+7/lk4tLmIy+O2CDerbVypflWwyNEoIW+OD95gcjlZBJVxEp2/z55OQG4a0qivrpwiCMNrAAvqrWWYp7rjkpNxuvgqDKsDrCMlQltLf97ND5vIwAscqCWH1MZoPCEShIhsbHQa+EWaDR5EY3bXsGMaqPWTitUpBvHUhYJkeSmaW3cMxOAKYyxqApbhb4OnXAntjxYJ8ltjJ2nw+27erLOeMzhdxpt6srE+dO1Kh11vLJ+5u+bZdq3YttQ5BfPzOu6jVzSHlj3NovkyyIVOLgzM0JnNYulA8sExwr0ZM1vYq32cpmYYCu6hvXUeIga9gihXKFx6Xb0I7/3b9/d0XOeDhJw7+KJBvaCeu3NOP0Gle97Jwo2KZzU7xxFAkyLVa5o2lsDvXoOoyEQmyTVSW9jIR8CU08RS2gSy8IcaGW8etw+A+8Bjsq5Ly88yjUfoDEnKSU0zvdWhdv8/ZpF2ka5nApHXSSvrBZzDJGDshZlFC/tiVpfXk/1vtp4zYcQprrGb+XqgifS35HkNaqiv86IQQzb1WSaT4fX3rj4CZWejz6/N7SnDm0CXzdNGwbY88B27WtCBTnwotlBUyXHPlJIe+h3p7+RUQGaMw="
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,99 @@
+# Zipkin Release Process
+
+This repo uses semantic versions. Please keep this in mind when choosing version numbers.
+
+1. **Alert others you are releasing**
+
+   There should be no commits made to master while the release is in progress (about 10 minutes). Before you start
+   a release, alert others on [gitter](https://gitter.im/openzipkin/zipkin) so that they don't accidentally merge
+   anything. If they do, and the build fails because of that, you'll have to recreate the release tag described below.
+
+1. **Push a git tag**
+
+   The tag should be of the format `release-N.M.L`, for example `release-3.7.1`.
+
+1. **Wait for Travis CI**
+
+   This part is controlled by [`travis/publish.sh`](travis/publish.sh). It creates a bunch of new commits, bumps
+   the version, publishes artifacts and syncs to Maven Central.
+
+## Credentials
+
+Credentials of various kind are needed for the release process to work. If you notice something
+failing due to unauthorized, re-encrypt them using instructions at the bottom of the `.travis.yml`
+
+Ex You'll see comments like this:
+```yaml
+env:
+  global:
+  # Ex. travis encrypt BINTRAY_USER=your_github_account
+  - secure: "VeTO...
+```
+
+To re-encrypt, you literally run the commands with relevant values and replace the "secure" key with the output:
+
+```bash
+$ travis encrypt BINTRAY_USER=adrianmole
+Please add the following to your .travis.yml file:
+
+  secure: "mQnECL+dXc5l9wCYl/wUz+AaYFGt/1G31NAZcTLf2RbhKo8mUenc4hZNjHCEv+4ZvfYLd/NoTNMhTCxmtBMz1q4CahPKLWCZLoRD1ExeXwRymJPIhxZUPzx9yHPHc5dmgrSYOCJLJKJmHiOl9/bJi123456="
+```
+
+### Troubleshooting invalid credentials
+
+If you receive a '401 unauthorized' failure from jCenter or Bintray, it is
+likely `BINTRAY_USER` or `BINTRAY_KEY` entries are invalid, or possibly the user
+associated with them does not have rights to upload.
+
+The least destructive test is to try to publish a snapshot manually. By passing
+the values Travis would use, you can kick off a snapshot from your laptop. This
+is a good way to validate that your unencrypted credentials are authorized.
+
+Here's an example of a snapshot deploy with specified credentials.
+```bash
+$ BINTRAY_USER=adrianmole BINTRAY_KEY=ed6f20bde9123bbb2312b221 TRAVIS_PULL_REQUEST=false TRAVIS_TAG= TRAVIS_BRANCH=master travis/publish.sh
+```
+
+## First release of the year
+
+The license plugin verifies license headers of files include a copyright notice indicating the years a file was affected.
+This information is taken from git history. There's a once-a-year problem with files that include version numbers (pom.xml).
+When a release tag is made, it increments version numbers, then commits them to git. On the first release of the year,
+further commands will fail due to the version increments invalidating the copyright statement. The way to sort this out is
+the following:
+
+Before you do the first release of the year, move the SNAPSHOT version back and forth from whatever the current is.
+In-between, re-apply the licenses.
+```bash
+$ ./mvnw versions:set -DnewVersion=1.3.3-SNAPSHOT -DgenerateBackupPoms=false
+$ ./mvnw com.mycila:license-maven-plugin:format
+$ ./mvnw versions:set -DnewVersion=1.3.2-SNAPSHOT -DgenerateBackupPoms=false
+$ git commit -am"Adjusts copyright headers for this year"
+```
+
+## Manually releasing
+
+If for some reason, you lost access to CI or otherwise cannot get automation to work, bear in mind this is a normal maven project, and can be released accordingly. The main thing to understand is that libraries are not GPG signed here (it happens at bintray), and also that there is a utility to synchronise to maven central. Note that if for some reason [bintray is down](https://status.bintray.com/), the below will not work.
+
+```bash
+# First, set variable according to your personal credentials. These would normally be decrypted from .travis.yml
+BINTRAY_USER=your_github_account
+BINTRAY_KEY=xxx-https://bintray.com/profile/edit-xxx
+SONATYPE_USER=your_sonatype_account
+SONATYPE_PASSWORD=your_sonatype_password
+VERSION=xx-version-to-release-xx
+
+# now from latest master, prepare the release. We are intentionally deferring pushing commits
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion=$VERSION -Darguments="-DskipTests -Dlicense.skip=true" release:prepare  -DpushChanges=false
+
+# once this works, deploy and synchronize to maven central
+git checkout $VERSION
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
+./mvnw --batch-mode -s ./.settings.xml -nsu -N io.zipkin.centralsync-maven-plugin:centralsync-maven-plugin:sync
+
+# if all the above worked, clean up stuff and push the local changes.
+./mvnw release:clean
+git checkout master
+git push
+git push --tags
+```

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.github.openzipkin-contrib.zipkin-secondary-sampling</groupId>
+    <groupId>io.zipkin.contrib.zipkin-secondary-sampling</groupId>
     <artifactId>zipkin-secondary-sampling-parent</artifactId>
     <version>0.1.0-SNAPSHOT</version>
   </parent>

--- a/brave/README.md
+++ b/brave/README.md
@@ -38,7 +38,7 @@ Setup this:
 Depend on this:
 ```xml
   <dependency>
-    <groupId>io.github.openzipkin-contrib.zipkin-secondary-sampling</groupId>
+    <groupId>io.zipkin.contrib.zipkin-secondary-sampling</groupId>
     <artifactId>brave-secondary-sampling</artifactId>
     <version>master-SNAPSHOT</version>
   </dependency>
@@ -58,6 +58,6 @@ Exclude brave from transitive deps
       </exclusion>
     </exclusions>
   </dependency>
-```  
+```
 
 TODO more instructions

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -18,7 +18,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <groupId>io.github.openzipkin-contrib.zipkin-secondary-sampling</groupId>
+    <groupId>io.zipkin.contrib.zipkin-secondary-sampling</groupId>
     <artifactId>zipkin-secondary-sampling-parent</artifactId>
     <version>0.1.0-SNAPSHOT</version>
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,12 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.github.openzipkin-contrib.zipkin-secondary-sampling</groupId>
+  <groupId>io.zipkin.contrib.zipkin-secondary-sampling</groupId>
   <artifactId>zipkin-secondary-sampling-parent</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -38,17 +40,25 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <!-- This allows you to test feature branches with jitpack -->
-<!--    <brave.groupId>com.github.openzipkin.brave</brave.groupId>-->
-<!--    <brave.version>master-SNAPSHOT</brave.version>-->
+    <!--    <brave.groupId>com.github.openzipkin.brave</brave.groupId>-->
+    <!--    <brave.version>master-SNAPSHOT</brave.version>-->
     <brave.groupId>io.zipkin.brave</brave.groupId>
     <brave.version>5.8.0</brave.version>
 
     <!-- override to set exclusions per-project -->
-    <errorprone.args />
+    <errorprone.args/>
     <errorprone.version>2.3.3</errorprone.version>
 
-    <license-maven-plugin.version>3.0</license-maven-plugin.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
+    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+    <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+    <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
+    <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+    <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+    <license-maven-plugin.version>3.0</license-maven-plugin.version>
   </properties>
 
   <name>Zipkin Secondary Sampling (Parent)</name>
@@ -71,8 +81,11 @@
 
   <scm>
     <url>https://github.com/openzipkin-contrib/zipkin-secondary-sampling</url>
-    <connection>scm:git:https://github.com/openzipkin-contrib/zipkin-secondary-sampling.git</connection>
-    <developerConnection>scm:git:https://github.com/openzipkin-contrib/zipkin-secondary-sampling.git</developerConnection>
+    <connection>scm:git:https://github.com/openzipkin-contrib/zipkin-secondary-sampling.git
+    </connection>
+    <developerConnection>
+      scm:git:https://github.com/openzipkin-contrib/zipkin-secondary-sampling.git
+    </developerConnection>
     <tag>HEAD</tag>
   </scm>
 
@@ -90,12 +103,16 @@
     <url>https://github.com/openzipkin-contrib/zipkin-secondary-sampling/issues</url>
   </issueManagement>
 
-  <repositories>
+  <distributionManagement>
     <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
+      <id>bintray</id>
+      <url>https://api.bintray.com/maven/openzipkin/maven/brave/;publish=1</url>
     </repository>
-  </repositories>
+    <snapshotRepository>
+      <id>jfrog-snapshots</id>
+      <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <dependencyManagement>
     <dependencies>
@@ -134,7 +151,6 @@
     </dependency>
   </dependencies>
 
-
   <build>
     <pluginManagement>
       <plugins>
@@ -144,13 +160,13 @@
           <artifactId>maven</artifactId>
           <version>0.7.6</version>
           <configuration>
-            <maven>3.6.1</maven>
+            <maven>3.6.2</maven>
           </configuration>
         </plugin>
 
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>${maven-compiler-plugin.version}</version>
           <inherited>true</inherited>
           <configuration>
             <!-- Retrolambda will rewrite lambdas as Java 6 bytecode -->
@@ -185,13 +201,14 @@
 
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>${maven-jar-plugin.version}</version>
       </plugin>
 
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
       </plugin>
+
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
@@ -229,15 +246,36 @@
 
       <plugin>
         <artifactId>maven-install-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>${maven-install-plugin.version}</version>
       </plugin>
 
       <!-- Uploads occur as a last step (which also adds checksums) -->
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>${maven-deploy-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>${maven-release-plugin.version}</version>
+        <configuration>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>release</releaseProfiles>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <!-- to match zipkin-scala (openzipkin/zipkin) -->
+          <tagNameFormat>@{project.version}</tagNameFormat>
+        </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>io.zipkin.centralsync-maven-plugin</groupId>
+        <artifactId>centralsync-maven-plugin</artifactId>
+        <version>0.1.1</version>
+        <configuration>
+          <subject>openzipkin-contrib</subject>
+          <repo>maven</repo>
+          <packageName>zipkin-secondary-sampling</packageName>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
@@ -282,7 +320,7 @@
 
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>${maven-enforcer-plugin.version}</version>
         <executions>
           <execution>
             <id>enforce-java</id>
@@ -303,6 +341,45 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <!-- Creates source jar -->
+          <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${maven-source-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- Creates javadoc jar -->
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${maven-javadoc-plugin.version}</version>
+            <configuration>
+              <failOnError>false</failOnError>
+              <!-- hush pedantic warnings: we don't put param and return on everything! -->
+              <doclint>none</doclint>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>error-prone-9+</id>
       <activation>

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -euo pipefail
+set -x
+
+build_started_by_tag() {
+  if [ "${TRAVIS_TAG}" == "" ]; then
+    echo "[Publishing] This build was not started by a tag, publishing snapshot"
+    return 1
+  else
+    echo "[Publishing] This build was started by the tag ${TRAVIS_TAG}, publishing release"
+    return 0
+  fi
+}
+
+is_pull_request() {
+  if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    echo "[Not Publishing] This is a Pull Request"
+    return 0
+  else
+    echo "[Publishing] This is not a Pull Request"
+    return 1
+  fi
+}
+
+is_travis_branch_master() {
+  if [ "${TRAVIS_BRANCH}" = master ]; then
+    echo "[Publishing] Travis branch is master"
+    return 0
+  else
+    echo "[Not Publishing] Travis branch is not master"
+    return 1
+  fi
+}
+
+check_travis_branch_equals_travis_tag() {
+  #Weird comparison comparing branch to tag because when you 'git push --tags'
+  #the branch somehow becomes the tag value
+  #github issue: https://github.com/travis-ci/travis-ci/issues/1675
+  if [ "${TRAVIS_BRANCH}" != "${TRAVIS_TAG}" ]; then
+    echo "Travis branch does not equal Travis tag, which it should, bailing out."
+    echo "  github issue: https://github.com/travis-ci/travis-ci/issues/1675"
+    exit 1
+  else
+    echo "[Publishing] Branch (${TRAVIS_BRANCH}) same as Tag (${TRAVIS_TAG})"
+  fi
+}
+
+check_release_tag() {
+    tag="${TRAVIS_TAG}"
+    if [[ "$tag" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+        echo "Build started by version tag $tag. During the release process tags like this"
+        echo "are created by the 'release' Maven plugin. Nothing to do here."
+        exit 0
+    elif [[ ! "$tag" =~ ^release-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+        echo "You must specify a tag of the format 'release-0.0.0' to release this project."
+        echo "The provided tag ${tag} doesn't match that. Aborting."
+        exit 1
+    fi
+}
+
+print_project_version() {
+  ./mvnw help:evaluate -N -Dexpression=project.version|sed -n '/^[0-9]/p'
+}
+
+is_release_commit() {
+  project_version="$(print_project_version)"
+  if [[ "$project_version" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+    echo "Build started by release commit $project_version. Will synchronize to maven central."
+    return 0
+  else
+    return 1
+  fi
+}
+
+release_version() {
+    echo "${TRAVIS_TAG}" | sed 's/^release-//'
+}
+
+safe_checkout_master() {
+  # We need to be on a branch for release:perform to be able to create commits, and we want that branch to be master.
+  # But we also want to make sure that we build and release exactly the tagged version, so we verify that the remote
+  # master is where our tag is.
+  git checkout -B master
+  git fetch origin master:origin/master
+  commit_local_master="$(git show --pretty='format:%H' master)"
+  commit_remote_master="$(git show --pretty='format:%H' origin/master)"
+  if [ "$commit_local_master" != "$commit_remote_master" ]; then
+    echo "Master on remote 'origin' has commits since the version under release, aborting"
+    exit 1
+  fi
+}
+
+#----------------------
+# MAIN
+#----------------------
+
+if ! is_pull_request && build_started_by_tag; then
+  check_travis_branch_equals_travis_tag
+  check_release_tag
+fi
+
+# During a release upload, don't run tests as they can flake or overrun the max time allowed by Travis.
+# skip license on travis due to #1512
+if is_release_commit; then
+  true
+else
+  ./mvnw verify -nsu -Dlicense.skip=true
+fi
+
+# If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
+if is_pull_request; then
+  true
+
+# If we are on master, we will deploy the latest snapshot or release version
+#   - If a release commit fails to deploy for a transient reason, delete the broken version from bintray and click rebuild
+elif is_travis_branch_master; then
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests -Dlicense.skip=true deploy
+
+  # If the deployment succeeded, sync it to Maven Central. Note: this needs to be done once per project, not module, hence -N
+  if is_release_commit; then
+    ./mvnw --batch-mode -s ./.settings.xml -nsu -N io.zipkin.centralsync-maven-plugin:centralsync-maven-plugin:sync
+  fi
+
+# If we are on a release tag, the following will update any version references and push a version tag for deployment.
+elif build_started_by_tag; then
+  safe_checkout_master
+  # skip license on travis due to #1512
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests -Dlicense.skip=true" release:prepare
+fi


### PR DESCRIPTION
https://bintray.com/openzipkin-contrib/maven/zipkin-secondary-sampling

First step post-merge is to check snapshots publish. After that, we
should do a release by creating a tag release-0.1.0

The first release will not complete because you cannot setup maven
central until there's a version. Once 0.1.0 exists in bintray, we can
click to allow it to be published.

See #22